### PR TITLE
feat: service user client id-secret support

### DIFF
--- a/core/authenticate/context.go
+++ b/core/authenticate/context.go
@@ -44,3 +44,15 @@ func GetTokenFromContext(ctx context.Context) (string, bool) {
 	}
 	return tokenHeaders[0], true
 }
+
+func GetSecretFromContext(ctx context.Context) (string, bool) {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", false
+	}
+	secretHeaders := md.Get(consts.UserSecretGatewayKey)
+	if len(secretHeaders) == 0 || len(secretHeaders[0]) == 0 {
+		return "", false
+	}
+	return secretHeaders[0], true
+}

--- a/core/serviceuser/errors.go
+++ b/core/serviceuser/errors.go
@@ -5,6 +5,7 @@ import "errors"
 var (
 	ErrNotExist     = errors.New("service user doesn't exist")
 	ErrCredNotExist = errors.New("service user credential doesn't exist")
+	ErrInvalidCred  = errors.New("service user credential is invalid")
 	ErrInvalidID    = errors.New("service user id is invalid")
 	ErrConflict     = errors.New("service user already exist")
 	ErrEmptyKey     = errors.New("empty key")

--- a/core/serviceuser/filter.go
+++ b/core/serviceuser/filter.go
@@ -3,5 +3,7 @@ package serviceuser
 type Filter struct {
 	ServiceUserID string
 	OrgID         string
+	IsKey         bool
+	IsSecret      bool
 	State         State
 }

--- a/core/serviceuser/serviceuser.go
+++ b/core/serviceuser/serviceuser.go
@@ -42,7 +42,7 @@ type Credential struct {
 	ServiceUserID string
 
 	// SecretHash used for basic auth
-	SecretHash string
+	SecretHash []byte
 
 	// PublicKey used for JWT verification using RSA
 	PublicKey jwk.Set
@@ -54,4 +54,10 @@ type Credential struct {
 	Metadata  metadata.Metadata
 	CreatedAt time.Time
 	UpdatedAt time.Time
+}
+
+type Secret struct {
+	ID        string
+	Value     []byte
+	CreatedAt time.Time
 }

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/gorilla/securecookie v1.1.1
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0
+	github.com/gtank/cryptopasta v0.0.0-20170601214702-1f550f6f2f69
 	github.com/jackc/pgconn v1.13.0
 	github.com/jackc/pgerrcode v0.0.0-20220416144525-469b46aa5efa
 	github.com/jackc/pgx/v4 v4.17.2

--- a/go.sum
+++ b/go.sum
@@ -1330,6 +1330,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.1/go.mod h1:G+WkljZi4mflcqVxYSgv
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3/go.mod h1:o//XUCC/F+yRGJoPO/VU0GSB0f8Nhgmxx0VIRUvaC0w=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 h1:1JYBfzqrWPcCclBwxFCPAou9n+q86mfnu7NAeHfte7A=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0/go.mod h1:YDZoGHuwE+ov0c8smSH49WLF3F2LaWnYYuDVd+EWrc0=
+github.com/gtank/cryptopasta v0.0.0-20170601214702-1f550f6f2f69 h1:7xsUJsB2NrdcttQPa7JLEaGzvdbk7KvfrjgHZXOQRo0=
+github.com/gtank/cryptopasta v0.0.0-20170601214702-1f550f6f2f69/go.mod h1:YLEMZOtU+AZ7dhN9T/IpGhXVGly2bvkJQ+zxj3WeVQo=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hanwen/go-fuse v1.0.0/go.mod h1:unqXarDXqzAk0rt98O2tVndEPIpUgLD9+rwFisZH3Ok=
 github.com/hanwen/go-fuse/v2 v2.1.0/go.mod h1:oRyA5eK+pvJyv5otpO/DgccS8y/RvYMaO00GgRLGryc=

--- a/internal/store/postgres/serviceuser.go
+++ b/internal/store/postgres/serviceuser.go
@@ -59,7 +59,8 @@ func (s ServiceUserCredential) transform() (serviceuser.Credential, error) {
 		}
 	}
 	var keySet jwk.Set
-	if len(s.PublicKey) > 0 {
+	if len(s.SecretHash.String) == 0 {
+		// if a secret hash is created, public key would be null
 		set, err := jwk.Parse(s.PublicKey)
 		if err != nil {
 			return serviceuser.Credential{}, fmt.Errorf("failed to parse public key: %w", err)
@@ -70,7 +71,7 @@ func (s ServiceUserCredential) transform() (serviceuser.Credential, error) {
 	return serviceuser.Credential{
 		ID:            s.ID,
 		ServiceUserID: s.ServiceUserID,
-		SecretHash:    s.SecretHash.String,
+		SecretHash:    []byte(s.SecretHash.String),
 		PublicKey:     keySet,
 		Title:         s.Title.String,
 		Metadata:      unmarshalledMetadata,

--- a/internal/store/postgres/user_repository.go
+++ b/internal/store/postgres/user_repository.go
@@ -94,7 +94,7 @@ func (r UserRepository) GetByName(ctx context.Context, name string) (user.User, 
 	var fetchedUser User
 	query, params, err := dialect.From(TABLE_USERS).
 		Where(goqu.Ex{
-			"name": name,
+			"name": strings.ToLower(name),
 		}).ToSQL()
 	if err != nil {
 		return user.User{}, fmt.Errorf("%w: %s", queryErr, err)
@@ -131,8 +131,8 @@ func (r UserRepository) Create(ctx context.Context, usr user.User) (user.User, e
 	}
 
 	insertRow := goqu.Record{
-		"name":  usr.Name,
-		"email": usr.Email,
+		"name":  strings.ToLower(usr.Name),
+		"email": strings.ToLower(usr.Email),
 		"title": usr.Title,
 	}
 	if usr.State != "" {
@@ -311,12 +311,11 @@ func (r UserRepository) UpdateByEmail(ctx context.Context, usr user.User) (user.
 	err := r.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {
 		updateQuery, params, err := dialect.Update(TABLE_USERS).Set(
 			goqu.Record{
-				"name":       usr.Name,
 				"title":      usr.Title,
 				"updated_at": goqu.L("now()"),
 			}).Where(
 			goqu.Ex{
-				"email": usr.Email,
+				"email": strings.ToLower(usr.Email),
 			},
 		).Returning("created_at", "deleted_at", "email", "id", "name", "state", "title", "updated_at").ToSQL()
 		if err != nil {
@@ -372,7 +371,6 @@ func (r UserRepository) UpdateByID(ctx context.Context, usr user.User) (user.Use
 	err := r.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {
 		query, params, err := dialect.Update(TABLE_USERS).Set(
 			goqu.Record{
-				"name":       usr.Name,
 				"title":      usr.Title,
 				"updated_at": goqu.L("now()"),
 			}).Where(
@@ -436,12 +434,11 @@ func (r UserRepository) UpdateByName(ctx context.Context, usr user.User) (user.U
 	err := r.dbc.WithTxn(ctx, sql.TxOptions{}, func(tx *sqlx.Tx) error {
 		query, params, err := dialect.Update(TABLE_USERS).Set(
 			goqu.Record{
-				"name":       usr.Name,
 				"title":      usr.Name,
 				"updated_at": goqu.L("now()"),
 			}).Where(
 			goqu.Ex{
-				"slug": usr.ID,
+				"name": strings.ToLower(usr.Name),
 			},
 		).Returning("created_at", "deleted_at", "email", "id", "name", "title", "updated_at").ToSQL()
 		if err != nil {
@@ -495,7 +492,7 @@ func (r UserRepository) GetByEmail(ctx context.Context, email string) (user.User
 
 	query, params, err := dialect.From(TABLE_USERS).Where(
 		goqu.Ex{
-			"email": email,
+			"email": strings.ToLower(email),
 		}).Where(notDisabledUserExp).ToSQL()
 
 	if err != nil {

--- a/pkg/server/consts/gateway.go
+++ b/pkg/server/consts/gateway.go
@@ -19,6 +19,7 @@ const (
 	SessionDeleteGatewayKey = "gateway-session-delete"
 	UserTokenGatewayKey     = "gateway-user-token"
 	LocationGatewayKey      = "gateway-location"
+	UserSecretGatewayKey    = "gateway-user-secret"
 
 	// UserTokenRequestKey is returned from the application to client containing user details in
 	// response headers

--- a/pkg/server/interceptors/session.go
+++ b/pkg/server/interceptors/session.go
@@ -144,6 +144,10 @@ func (h Session) UnaryGRPCRequestHeadersAnnotator() grpc.UnaryServerInterceptor 
 						incomingMD.Set(consts.UserTokenGatewayKey, tokenVal)
 					}
 				}
+				secretVal := strings.TrimSpace(strings.TrimPrefix(authHeader[0], "Basic "))
+				if len(secretVal) > 0 {
+					incomingMD.Set(consts.UserSecretGatewayKey, secretVal)
+				}
 			}
 
 			ctx = metadata.NewIncomingContext(ctx, incomingMD)


### PR DESCRIPTION
Serviceusers can now send base64 encoded `clientid:clientsecret` in `Authorization` header as `Basic <val>` to authenticate.